### PR TITLE
Introduce the `onlyDifferent` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ jobs:
 | `verifyCertificate` | Verify server’s certificate to be signed by a known Certificate Authority | No       | `'true'`           |
 | `fingerprint`       | Key fingerprint of the host we want to connect to                         | No       | `''`               |
 | `onlyNewer`         | Only transfer files that are newer than the ones on the remote server     | No       | `'true'`           |
+| `onlyDifferent`     | Only transfer files that are different than the ones on the remote server | No       | `'false'`          |
 | `restoreMTime`      | Restore the modification time of the files (if necessary)                 | No       | `'true'`           |
 | `parallel`          | Number of parallel transfers                                              | No       | `'1'`              |
 | `settings`          | Any additional lftp settings to configure                                 | No       | `''`               |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Only transfer files that are newer than the ones on the remote server'
     required: false
     default: 'true'
+  onlyDifferent:
+    description: 'Only transfer files that are different than the ones on the remote server'
+    required: false
+    default: 'false'
   parallel:
     description: 'Number of parallel transfers'
     required: false

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,7 @@
 # - `INPUT_VERIFYCERTIFICATE` — Verify server's certificate to be signed by a known Certificate Authority
 # - `INPUT_FINGERPRINT` — The key fingerprint of the host we want to connect to
 # - `INPUT_ONLYNEWER` — Only transfer files that are newer than the ones on the remote server
+# - `INPUT_ONLYDIFFERENT` — Only transfer files that are different than the ones on the remote server
 # - `INPUT_PARALLEL` — Number of parallel transfers
 # - `INPUT_SETTINGS` — Any additional lftp settings to configure
 # - `INPUT_LOCALDIR` — The local directory to copy to (assuming `reverse` is set to `true`)
@@ -283,8 +284,8 @@ else
   echo "Ignoring invalid value for the 'parallel' input: ${INPUT_PARALLEL}"
 fi
 
-# Restore timestamps if the `--only-newer` flag is set
-if is_true "${INPUT_ONLYNEWER}"; then
+# Restore timestamps if the `onlyNewer` or `onlyDifferent` input flag is set
+if is_true "${INPUT_ONLYNEWER}" || is_true "${INPUT_ONLYDIFFERENT}"; then
   echo "Restoring the original modification time of files based on the date of the most recent commit..."
 
   # Disable Git ownership check


### PR DESCRIPTION
Suggested by @jfaMan in #2

>[…] add an input parameter similar to onlyNewer but instead of uploading files with a more recent modification date upload files if the modification date has simply changed?
