### PR TITLE
Introduce `restoreMTime` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ jobs:
 | `verifyCertificate` | Verify server’s certificate to be signed by a known Certificate Authority | No       | `'true'`           |
 | `fingerprint`       | Key fingerprint of the host we want to connect to                         | No       | `''`               |
 | `onlyNewer`         | Only transfer files that are newer than the ones on the remote server     | No       | `'true'`           |
-| `onlyDifferent`     | Only transfer files that are different than the ones on the remote server | No       | `'false'`          |
-| `restoreMTime`      | Restore the modification time of the files (if necessary)                 | No       | `'true'`           |
+| `restoreMTime`      | Restore the modification time of the files                                | No       | `'true'`           |
 | `parallel`          | Number of parallel transfers                                              | No       | `'1'`              |
 | `settings`          | Any additional lftp settings to configure                                 | No       | `''`               |
 | `localDir`          | The local directory to copy from (assuming `reverse` is set to `true`)    | No       | `'.'`              |

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,10 @@ inputs:
     description: 'Only transfer files that are newer than the ones on the remote server'
     required: false
     default: 'true'
-  onlyDifferent:
-    description: 'Only transfer files that are different than the ones on the remote server'
+  restoreMTime:
+    description: 'Restore the modification time of the files'
     required: false
-    default: 'false'
+    default: 'true'
   parallel:
     description: 'Number of parallel transfers'
     required: false

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@
 # - `INPUT_VERIFYCERTIFICATE` — Verify server's certificate to be signed by a known Certificate Authority
 # - `INPUT_FINGERPRINT` — The key fingerprint of the host we want to connect to
 # - `INPUT_ONLYNEWER` — Only transfer files that are newer than the ones on the remote server
-# - `INPUT_ONLYDIFFERENT` — Only transfer files that are different than the ones on the remote server
+# - `INPUT_RESTOREMTIME` - Restore the modification time of the files
 # - `INPUT_PARALLEL` — Number of parallel transfers
 # - `INPUT_SETTINGS` — Any additional lftp settings to configure
 # - `INPUT_LOCALDIR` — The local directory to copy to (assuming `reverse` is set to `true`)
@@ -284,8 +284,8 @@ else
   echo "Ignoring invalid value for the 'parallel' input: ${INPUT_PARALLEL}"
 fi
 
-# Restore timestamps if the `onlyNewer` or `onlyDifferent` input flag is set
-if is_true "${INPUT_ONLYNEWER}" || is_true "${INPUT_ONLYDIFFERENT}"; then
+# Restore timestamps if the `restoreMTime` input is set to `true`
+if is_true "${INPUT_RESTOREMTIME}"; then
   echo "Restoring the original modification time of files based on the date of the most recent commit..."
 
   # Disable Git ownership check


### PR DESCRIPTION
When the `restoreMTime` input is set to `true`, the action will restore the modification time of the files.